### PR TITLE
Add required `data-wp-interactive` attribute to router region

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -217,6 +217,7 @@ function render_block_query( $block_content, $block ) {
 	$block_content->next_tag();
 
 	// Always allow region updates on interactivity, use standard core region naming.
+	$block_content->set_attribute( 'data-wp-interactive', 'query-filter' );
 	$block_content->set_attribute( 'data-wp-router-region', 'query-' . ( $block['attrs']['queryId'] ?? 0 ) );
 
 	return (string) $block_content;


### PR DESCRIPTION
As of WP 6.9, router regions inside interactive elements must include the `data-wp-interactive` directive to receive the corresponding namespace. Without it, the region's content won't refresh when `navigate()` is called.

...is what I gather. I'm still confused. :)

This fixes an issue we had with an implementation of query-filter where the interactivity API requests was firing fine, but was not replacing any of the results in a query.

See: https://make.wordpress.org/core/2025/11/12/interactivity-apis-client-navigation-improvements-in-wordpress-6-9/